### PR TITLE
Add `packages: read` permission to GitHub Actions javadoc-publish.yml workflow

### DIFF
--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: read
     steps:
       - name: Deploy JavaDoc 🚀
         uses: MathieuSoysal/Javadoc-publisher.yml@v2.5.0


### PR DESCRIPTION
To allow download dependencies from GitHub Packages Apache Maven
